### PR TITLE
Integrate finalized visuals

### DIFF
--- a/components/sections/FeaturesSection.tsx
+++ b/components/sections/FeaturesSection.tsx
@@ -1,0 +1,52 @@
+import Image from 'next/image';
+
+const features = [
+  {
+    title: 'Quiromancia',
+    description: 'Descubre el mapa estelar de tu alma en las líneas de tu mano.',
+    image: '/sections/quiromancia.png',
+  },
+  {
+    title: 'Tarot',
+    description: 'Dialoga con los arquetipos del universo a través del lenguaje simbólico de las cartas.',
+    image: '/sections/tarot.png',
+  },
+  {
+    title: 'Astrología',
+    description: 'Sincroniza tu ritmo interior con las danzas cósmicas de los planetas y las estrellas.',
+    image: '/sections/astrologia.png',
+  },
+  {
+    title: 'Alquimia',
+    description: 'Fusiona la sabiduría natural y la intención para transmutar tu bienestar.',
+    image: '/sections/alquimia.png',
+  },
+];
+
+export default function FeaturesSection() {
+  return (
+    <section className="py-16 bg-q-violeta text-q-blanco-calido">
+      <div className="container mx-auto grid gap-8 md:grid-cols-2 lg:grid-cols-4 px-4">
+        {features.map(feature => (
+          <div
+            key={feature.title}
+            className="bg-q-indigo rounded-lg overflow-hidden shadow-lg flex flex-col"
+          >
+            <div className="relative h-48 w-full">
+              <Image
+                src={feature.image}
+                alt={`Ilustración de ${feature.title}`}
+                fill
+                className="object-cover"
+              />
+            </div>
+            <div className="p-4 flex flex-col flex-1">
+              <h3 className="font-serif-elegant text-xl mb-2">{feature.title}</h3>
+              <p className="text-sm flex-1">{feature.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/sections/HeroSection.tsx
+++ b/components/sections/HeroSection.tsx
@@ -1,0 +1,16 @@
+'use client';
+import Image from 'next/image';
+
+export default function HeroSection() {
+  return (
+    <section className="h-screen w-full relative">
+      <Image
+        src="/hero/background.png"
+        alt="Portada de QuiróNova: NaoAI sosteniendo un loto luminoso."
+        fill={true}
+        className="object-cover"
+        priority={true}
+      />
+    </section>
+  );
+}

--- a/components/sections/PhilosophySection.tsx
+++ b/components/sections/PhilosophySection.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image';
+
+export default function PhilosophySection() {
+  return (
+    <section className="py-16 bg-q-indigo text-q-blanco-calido">
+      <div className="container mx-auto flex flex-col md:flex-row items-center gap-8 px-4">
+        <div className="md:w-1/2 space-y-4">
+          <h2 className="text-2xl font-serif-elegant">Nuestra Filosofía</h2>
+          <p>
+            En QuiróNova abrazamos la convergencia de ciencia y espiritualidad para
+            cultivar un camino de autodescubrimiento respetuoso y libre de dogmas.
+          </p>
+        </div>
+        <div className="md:w-1/2 relative h-64 w-full">
+          <Image
+            src="/sections/filosofia.png"
+            alt="Avatar de NaoAI, sonriendo con serenidad, representando la filosofía de QuiróNova."
+            fill
+            className="object-cover rounded-lg"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add HeroSection with full-screen background image
- list services in FeaturesSection with illustrative images
- update PhilosophySection to display NaoAI avatar

## Testing
- `npm install`
- `npm run build` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442c39e03c8332a4c4c98d7efe6862